### PR TITLE
update all backported import refs, backport more stdlib names

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ potential goals of `unpy`:
     - [x] [PEP 696][PEP696]: Backport [PEP 695][PEP695] type signatures i.f.f. it
     includes a type parameter with default
     - [x] [PEP 696][PEP696]: `typing.NoDefault` => `typing_extensions.NoDefault`
-    - [ ] `asyncio.QueueShutDown` => `builtins.Exception`
-    - [ ] `pathlib.UnsupportedOperation` => `builtins.NotImplementedError`
-    - [ ] `queue.ShutDown` => `builtins.Exception`
-    - [ ] `re.PatternError` => `re.error`
+    - [x] `asyncio.QueueShutDown` => `builtins.Exception`
+    - [x] `pathlib.UnsupportedOperation` => `builtins.NotImplementedError`
+    - [x] `queue.ShutDown` => `builtins.Exception`
+    - [x] `re.PatternError` => `re.error`
     - [x] `types.CapsuleType` => `typing_extensions.CapsuleType`
     - [ ] `typing.{ClassVar,Final}` => `typing_extensions.{ClassVar,Final}` when nested
     (python/cpython#89547)
@@ -295,7 +295,7 @@ potential goals of `unpy`:
     - [x] [PEP 695][PEP695]: Backport generic classes and protocols
     - [x] [PEP 695][PEP695]: `typing.TypeAliasType` => `typing_extensions.TypeAliasType`
     - [x] [PEP 688][PEP688]: `collections.abc.Buffer` => `typing_extensions.Buffer`
-    - [ ] [PEP 688][PEP688]: `inspect.BufferFlags` => `int` (#57)
+    - [x] [PEP 688][PEP688]: `inspect.BufferFlags` => `int` (jorenham/unpy#57)
 - Python 3.11 => 3.10
     - [x] [PEP 681][PEP681]: `typing.dataclass_transform` =>
     `typing_extensions.dataclass_transform`
@@ -306,7 +306,8 @@ potential goals of `unpy`:
     - [x] [PEP 646][PEP646]: `*Ts` => `typing_extensions.Unpack[Ts]`
     - [ ] Backport `typing.Any` base class (not recommended)
     - [ ] Backport `asyncio.TaskGroup` base classes
-    - [ ] `enum.ReprEnum` => `enum.Enum` and `enum.StrEnum` => `str & enum.Enum`
+    - [x] `enum.ReprEnum` => `enum.Enum`
+    - [ ] `enum.StrEnum` => `str & enum.Enum`
 - Generated `TypeVar`s
     - [ ] Prefix extracted `TypeVar`s names with `_`
     - [x] De-duplicate extracted typevar-likes with same name if equivalent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ executionEnvironments = [
 
 [tool.pytest.ini_options]
 testpaths = ["unpy", "tests"]
-addopts = ["-ra", "--strict-config", "--strict-markers", "--doctest-modules"]
+addopts = ["-ra", "-vv", "--strict-config", "--strict-markers", "--doctest-modules"]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
 filterwarnings = ["error"]
 log_cli_level = "INFO"


### PR DESCRIPTION
added the following backports:

- `python<3.13`: `asyncio.QueueShutDown` => `builtins.Exception`
- `python<3.11`: `enum.ReprEnum` => `enum.Enum`
- `python<3.12`: `inspect.BufferFlags` => `builtins.int` (unsupported as baseclass)
- `python<3.13`: `pathlib.UnsupportedOperation` => `builtins.NotImplementedError`
- `python<3.13`: `queue.ShutDown` => `builtins.Exception`
- `python<3.13`: `re.PatternError` => `re.error`

the relevant backporting code has also been simplified

fixes #57
