### PR TITLE
disallow quoted annotations, `__future__` imports, and runtime-only nodes

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -31,7 +31,6 @@ def test_comments(source: str) -> None:
         "__version__: str = '3.14'\n",
         "def concat(*args: str) -> str: ...\n",
         "class C:\n    def f(self, /) -> None: ...\n",
-        "raise NotImplementedError\n",
     ],
 )
 def test_already_compatible(source: str) -> None:

--- a/unpy/exceptions.py
+++ b/unpy/exceptions.py
@@ -1,0 +1,5 @@
+__all__ = ("StubError",)
+
+
+class StubError(TypeError):
+    pass


### PR DESCRIPTION
resolves #43
resolves #53
resolves #59