### PR TITLE
explicitly check for unsupported names

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,61 +288,61 @@ potential goals of `unpy`:
 
 - Python 3.13 => 3.12
     - [PEP 742][PEP742]
-        - [x] `typing.TypeIs` => `typing_extensions.TypeIs`
+        - `typing.TypeIs` => `typing_extensions.TypeIs`
     - [PEP 705][PEP705]
-        - [x] `typing.ReadOnly` => `typing_extensions.ReadOnly`
+        - `typing.ReadOnly` => `typing_extensions.ReadOnly`
     - [PEP 702][PEP702]
-        - [x] `warnings.deprecated` => `typing_extensions.deprecated`
+        - `warnings.deprecated` => `typing_extensions.deprecated`
     - [PEP 696][PEP696]
-        - [x] Backport [PEP 695][PEP695] type signatures with a default
-        - [x] `typing.NoDefault` => `typing_extensions.NoDefault`
+        - Backport [PEP 695][PEP695] type signatures with a default
+        - `typing.NoDefault` => `typing_extensions.NoDefault`
     - Exceptions
-        - [x] `asyncio.QueueShutDown` => `builtins.Exception`
-        - [x] `pathlib.UnsupportedOperation` => `builtins.NotImplementedError`
-        - [x] `queue.ShutDown` => `builtins.Exception`
-        - [x] `re.PatternError` => `re.error`
+        - `asyncio.QueueShutDown` => `builtins.Exception`
+        - `pathlib.UnsupportedOperation` => `builtins.NotImplementedError`
+        - `queue.ShutDown` => `builtins.Exception`
+        - `re.PatternError` => `re.error`
     - Typing
-        - [x] `types.CapsuleType` => `typing_extensions.CapsuleType`
-        - [x] `typing.{ClassVar,Final}` => `typing_extensions.{ClassVar,Final}` when
-        nested (python/cpython#89547)
+        - `types.CapsuleType` => `typing_extensions.CapsuleType`
+        - `typing.{ClassVar,Final}` => `typing_extensions.{ClassVar,Final}` when
+        nested
 - Python 3.12 => 3.11
     - [PEP 698][PEP698]
-        - [x] `typing.override` => `typing_extensions.override`
+        - `typing.override` => `typing_extensions.override`
     - [PEP 695][PEP695]
-        - [x] Backport `type _` aliases
-        - [x] Backport generic functions
-        - [x] Backport generic classes and protocols
-        - [x] `typing.TypeAliasType` => `typing_extensions.TypeAliasType`
+        - Backport `type _` aliases
+        - Backport generic functions
+        - Backport generic classes and protocols
+        - `typing.TypeAliasType` => `typing_extensions.TypeAliasType`
     - [PEP 688][PEP688]
-        - [x] `collections.abc.Buffer` => `typing_extensions.Buffer`
-        - [x] `inspect.BufferFlags` => `int`
+        - `collections.abc.Buffer` => `typing_extensions.Buffer`
+        - `inspect.BufferFlags` => `int`
 - Python 3.11 => 3.10
     - [PEP 681][PEP681]
-        - [x] `typing.dataclass_transform` => `typing_extensions.dataclass_transform`
+        - `typing.dataclass_transform` => `typing_extensions.dataclass_transform`
     - [PEP 675][PEP675]
-        - [x] `typing.LiteralString` => `typing_extensions.LiteralString`
+        - `typing.LiteralString` => `typing_extensions.LiteralString`
     - [PEP 673][PEP673]
-        - [x] `typing.Self` => `typing_extensions.Self`
+        - `typing.Self` => `typing_extensions.Self`
     - [PEP 655][PEP655]
-        - [x] `typing.[Not]Required` => `typing_extensions.[Not]Required`
+        - `typing.[Not]Required` => `typing_extensions.[Not]Required`
     - [PEP 654][PEP654]
-        - [ ] `builtins.BaseExceptionGroup` => ?  (disallowed for now)
-        - [ ] `builtins.ExceptionGroup` => ?  (disallowed for now)
+        - ~`builtins.BaseExceptionGroup`~
+        - ~`builtins.ExceptionGroup`~
     - [PEP 646][PEP646]
-        - [x] `typing.TypeVarTuple` => `typing_extensions.TypeVarTuple`
-        - [x] `typing.Unpack` => `typing_extensions.Unpack`
-        - [x] `*Ts` => `typing_extensions.Unpack[Ts]` with `Ts` a `TypeVarTuple`
+        - `typing.TypeVarTuple` => `typing_extensions.TypeVarTuple`
+        - `typing.Unpack` => `typing_extensions.Unpack`
+        - `*Ts` => `typing_extensions.Unpack[Ts]` with `Ts: TypeVarTuple`
     - `asyncio`
-        - [ ] `asyncio.TaskGroup` => ? (disallowed for now)
+        - ~`asyncio.TaskGroup`~
     - `enum`
-        - [x] `enum.ReprEnum` => `enum.Enum`
-        - [x] `enum.StrEnum` => `str & enum.Enum`
+        - `enum.ReprEnum` => `enum.Enum`
+        - `enum.StrEnum` => `str & enum.Enum`
     - `typing`
-        - [ ] `typing.Any` => `typing_extensions.Any` if subclassed (disallowed for now)
+        - `typing.Any` => `typing_extensions.Any` if subclassed (not recommended)
 - Generated `TypeVar`s
-    - [x] Prefix extracted `TypeVar`s names with `_` (jorenham/unpy#38)
     - [x] De-duplicate extracted typevar-likes with same name if equivalent
-    - [ ] Rename extracted typevar-likes with same name if not equivalent
+    - [x] Prefix the names of extracted typevar-likes with `_`
+    - [ ] Rename incompatible typevar-likes with the same name (jorenham/unpy#86)
 
 ### Simplification and refactoring
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -556,6 +556,37 @@ def test_import_capsule_type():
     assert pyi_out == pyi_expect
 
 
+def test_import_baseclass_Any():
+    pyi_in = _src("""
+    from typing import Any
+
+    class Evil(Any): ...
+    """)
+    pyi_expect = _src("""
+    from typing_extensions import Any
+
+    class Evil(Any): ...
+    """)
+    pyi_out = transform_source(pyi_in)
+    assert pyi_out == pyi_expect
+
+
+# there's no need to test the other `unpy._strlib._UNSUPPORTED_NAMES` as well
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from typing import Text",
+        "from typing import Text as _Text",
+        "import typing.Text",
+        "import typing.Text as _Text",
+        "import typing\n\nA: typing.Text = ''",
+    ],
+)
+def test_import_unsupported(source: str):
+    with pytest.raises(NotImplementedError):
+        transform_source(source)
+
+
 def test_backport_exceptions():
     pyi_in = _src("""
     import re

--- a/unpy/_stdlib.py
+++ b/unpy/_stdlib.py
@@ -23,25 +23,29 @@ DEFAULT_GLOBALS: Final[dict[str, type | object]] = {
 }
 
 UNSUPPORTED_NAMES: Final = {
-    "asyncio": {
-        "TaskGroup": (3, 11),
-    },
-    "builtins": {
-        "_IncompleteInputError": (3, 13),
-        "PythonFinalizationError": (3, 13),
-        "BaseExceptionGroup": (3, 11),
-        "ExceptionGroup": (3, 11),
-        "EncodingWarning": (3, 10),
-        "reveal_locals": (4, 0),
-        "reveal_type": (4, 0),
-    },
+    "ast.TryStar": (3, 11),
+    "ast.TypeAlias": (3, 12),
+    "ast.TypeVar": (3, 12),
+    "ast.TypeVarTuple": (3, 12),
+    "ast.ParamSpec": (3, 12),
+    "ast.PyCF_OPTIMIZED_AST": (3, 13),
+    "asyncio.TaskGroup": (3, 11),
+    "builtins._IncompleteInputError": (3, 13),
+    "builtins.PythonFinalizationError": (3, 13),
+    "builtins.BaseExceptionGroup": (3, 11),
+    "builtins.ExceptionGroup": (3, 11),
+    "builtins.EncodingWarning": (3, 10),
+    "builtins.reveal_locals": (4, 0),
+    "builtins.reveal_type": (4, 0),
+    "typing.ByteString": (4, 0),
+    "typing.Text": (4, 0),
+    "typing.cast": (4, 0),
+    "typing.reveal_type": (4, 0),
 }
 UNSUPPORTED_BASES: Final = {
     "builtins.object": (4, 0),
     "inspect.BufferFlags": (3, 12),
     "pathlib.Path": (3, 12),
-    "typing.Any": (3, 11),
-    "typing_extensions.Any": (3, 11),
 }
 
 
@@ -143,8 +147,8 @@ _BACKPORTS_DEPRECATED: Final = {
             ]
         },
         # contextlib
-        "ContextManager": ("contextlib", "ContextManager"),
-        "AsyncContextManager": ("contextlib", "AsyncContextManager"),
+        "ContextManager": ("contextlib", "AbstractContextManager"),
+        "AsyncContextManager": ("contextlib", "AbstractAsyncContextManager"),
         # re
         "Pattern": ("re", "Pattern"),
         "Match": ("re", "Match"),


### PR DESCRIPTION
... additionally

- (reluctantly) backport `typing.Any` when used as base class
- add unsupported `ast`  names
- improved testing
- reduces code duplication within the backporting code

resolves #84